### PR TITLE
Skip CPUID for macOS and non-x86 engines

### DIFF
--- a/src/fairyfishnet/downloads.py
+++ b/src/fairyfishnet/downloads.py
@@ -24,6 +24,8 @@ from .engine import open_process
 from .errors import ConfigError
 from .http_utils import is_newer_version, release_file_url, response_json
 
+X86_MACHINES = frozenset(("amd64", "x86_64", "x86", "i386", "i686"))
+
 
 def detect_cpu_capabilities():
     # Detects support for popcnt and pext instructions
@@ -83,18 +85,21 @@ def detect_cpu_capabilities():
 def stockfish_filename():
     machine = platform.machine().lower()
 
-    vendor, modern, bmi2 = detect_cpu_capabilities()
-    if modern and "Intel" in vendor and bmi2:
-        suffix = "-bmi2"
-    elif modern:
-        suffix = "-modern"
-    else:
-        suffix = ""
+    # macOS binaries do not use x86 feature suffixes, and CPUID is not
+    # available on ARM or other non-x86 architectures.
+    if os.name == "os2" or sys.platform == "darwin":
+        return "stockfish-osx-%s" % machine
+
+    suffix = ""
+    if machine in X86_MACHINES:
+        vendor, modern, bmi2 = detect_cpu_capabilities()
+        if modern and "Intel" in vendor and bmi2:
+            suffix = "-bmi2"
+        elif modern:
+            suffix = "-modern"
 
     if os.name == "nt":
         return "stockfish-windows-%s%s.exe" % (machine, suffix)
-    elif os.name == "os2" or sys.platform == "darwin":
-        return "stockfish-osx-%s" % machine
     elif os.name == "posix":
         return "stockfish-%s%s" % (machine, suffix)
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -22,3 +22,37 @@ def test_stockfish_filename_windows(monkeypatch):
     monkeypatch.setattr(downloads, "detect_cpu_capabilities", lambda: ("", False, False))
     monkeypatch.setattr(downloads.os, "name", "nt")
     assert downloads.stockfish_filename() == "stockfish-windows-amd64.exe"
+
+
+def test_stockfish_filename_macos_apple_silicon_skips_cpuid(monkeypatch):
+    monkeypatch.setattr(downloads.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(downloads.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        downloads,
+        "detect_cpu_capabilities",
+        lambda: (_ for _ in ()).throw(AssertionError("macOS must not run CPUID")),
+    )
+    assert downloads.stockfish_filename() == "stockfish-osx-arm64"
+
+
+def test_stockfish_filename_macos_x86_64_skips_unused_cpuid(monkeypatch):
+    monkeypatch.setattr(downloads.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(downloads.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        downloads,
+        "detect_cpu_capabilities",
+        lambda: (_ for _ in ()).throw(AssertionError("macOS filenames do not use CPUID features")),
+    )
+    assert downloads.stockfish_filename() == "stockfish-osx-x86_64"
+
+
+def test_stockfish_filename_linux_arm_skips_cpuid(monkeypatch):
+    monkeypatch.setattr(downloads.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(downloads.os, "name", "posix")
+    monkeypatch.setattr(downloads.sys, "platform", "linux")
+    monkeypatch.setattr(
+        downloads,
+        "detect_cpu_capabilities",
+        lambda: (_ for _ in ()).throw(AssertionError("non-x86 platforms must not run CPUID")),
+    )
+    assert downloads.stockfish_filename() == "stockfish-aarch64"


### PR DESCRIPTION
## Summary

- return the architecture-specific macOS filename before invoking x86 CPUID detection
- skip CPUID on ARM and other non-x86 Windows/Linux architectures
- retain modern/BMI2 selection for x86 Windows and Linux
- cover Apple Silicon, Intel macOS, and Linux ARM selection with platform fakes

This addresses the client-side failure in #65. Publishing matching macOS release assets is tracked as the deployment half of the fix.

## Validation

- `pytest tests/test_downloads.py` (6 passed)
- `pytest -m "not engine"` (90 passed)
- `pytest -m engine` (4 passed)
- `ruff check .`
- `ruff format --check .`
- `pyright`
