### PR TITLE
Fix Windows respawn after self-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,24 @@ jobs:
       - name: Run fast tests
         run: uv run --python ${{ matrix.python-version }} pytest -m "not engine"
 
+  windows-tests:
+    name: Windows tests (Python 3.14)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+          enable-cache: true
+      - name: Install Python
+        run: uv python install 3.14
+      - name: Sync environment
+        run: uv sync --locked --python 3.14
+      - name: Run fast tests
+        run: uv run --python 3.14 pytest -m "not engine"
+
   engine-tests:
     name: Fairy-Stockfish integration tests
     runs-on: ubuntu-latest

--- a/src/fairyfishnet/downloads.py
+++ b/src/fairyfishnet/downloads.py
@@ -180,6 +180,24 @@ def is_user_site_package():
     return os.path.abspath(__file__).startswith(os.path.join(user_site, ""))
 
 
+def _replace_process(executable, argv):
+    logging.debug("Restarting with executable: %s", executable)
+    if os.name == "nt":
+        # Windows has no true exec. Its CRT overlay starts a new process and
+        # terminates this one, which lets the invoking shell return while the
+        # replacement still owns the console. Keep this process alive until the
+        # replacement exits. Popen also quotes argument lists correctly for
+        # Windows paths and arguments containing spaces.
+        raise SystemExit(subprocess.call(argv, executable=executable, cwd=os.getcwd()))
+
+    os.execv(executable, argv)
+
+
+def _respawn_self():
+    argv = [sys.executable, "-m", "fairyfishnet"] + sys.argv[1:]
+    _replace_process(sys.executable, argv)
+
+
 def update_self():
     # Ensure current instance is installed as a package
     if __package__ is None:
@@ -266,11 +284,7 @@ def update_self():
     time.sleep(t)
 
     # Respawn through the stable package name after moving to a package layout.
-    argv = [sys.executable, "-m", "fairyfishnet"] + sys.argv[1:]
-
-    logging.debug("Restarting with execv: %s, argv: %s", sys.executable, " ".join(argv))
-
-    os.execv(sys.executable, argv)
+    _respawn_self()
 
 
 def update_available():

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,3 +1,7 @@
+import logging
+
+import pytest
+
 import fairyfishnet.downloads as downloads
 
 
@@ -56,3 +60,86 @@ def test_stockfish_filename_linux_arm_skips_cpuid(monkeypatch):
         lambda: (_ for _ in ()).throw(AssertionError("non-x86 platforms must not run CPUID")),
     )
     assert downloads.stockfish_filename() == "stockfish-aarch64"
+
+
+def test_respawn_self_uses_execv_on_posix(monkeypatch):
+    executable = "/opt/Fairy Fishnet/bin/python"
+    arguments = ["fairyfishnet", "--conf", "/srv/Fairy Fishnet/fishnet.ini", "run"]
+    expected = [executable, "-m", "fairyfishnet"] + arguments[1:]
+
+    monkeypatch.setattr(downloads.os, "name", "posix")
+    monkeypatch.setattr(downloads.sys, "executable", executable)
+    monkeypatch.setattr(downloads.sys, "argv", arguments)
+    monkeypatch.setattr(
+        downloads.subprocess,
+        "call",
+        lambda *args, **kwargs: pytest.fail("POSIX respawn must not start a child process"),
+    )
+
+    def execv(path, argv):
+        assert path == executable
+        assert argv == expected
+        raise RuntimeError("execv called")
+
+    monkeypatch.setattr(downloads.os, "execv", execv)
+
+    with pytest.raises(RuntimeError, match="execv called"):
+        downloads._respawn_self()
+
+
+def test_respawn_self_waits_on_windows_and_preserves_spaced_arguments(monkeypatch, caplog):
+    executable = r"C:\Program Files\Python\python.exe"
+    working_directory = r"C:\Fairy Fishnet Worker"
+    arguments = [
+        r"C:\Python Scripts\fairyfishnet.exe",
+        "--conf",
+        r"C:\Fairy Fishnet Worker\fishnet.ini",
+        "--key",
+        "secret-api-key",
+        "run",
+    ]
+    expected = [executable, "-m", "fairyfishnet"] + arguments[1:]
+    calls = []
+
+    monkeypatch.setattr(downloads.os, "name", "nt")
+    monkeypatch.setattr(downloads.os, "getcwd", lambda: working_directory)
+    monkeypatch.setattr(downloads.os, "execv", lambda *args: pytest.fail("Windows respawn must wait for a child"))
+    monkeypatch.setattr(downloads.sys, "executable", executable)
+    monkeypatch.setattr(downloads.sys, "argv", arguments)
+
+    def call(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return 23
+
+    monkeypatch.setattr(downloads.subprocess, "call", call)
+
+    with caplog.at_level(logging.DEBUG), pytest.raises(SystemExit) as exc_info:
+        downloads._respawn_self()
+
+    assert exc_info.value.code == 23
+    assert calls == [(expected, {"executable": executable, "cwd": working_directory})]
+    assert "secret-api-key" not in caplog.text
+
+
+@pytest.mark.skipif(downloads.os.name != "nt", reason="requires Windows process creation")
+def test_replace_process_waits_and_preserves_spaced_arguments_on_windows(tmp_path, monkeypatch):
+    working_directory = tmp_path / "working directory"
+    working_directory.mkdir()
+    result_file = working_directory / "result with spaces.txt"
+    spaced_argument = "argument with spaces"
+    child_code = (
+        "import os, pathlib, sys; "
+        "pathlib.Path(sys.argv[1]).write_text(os.getcwd() + '\\n' + sys.argv[2], encoding='utf-8'); "
+        "raise SystemExit(17)"
+    )
+    argv = [downloads.sys.executable, "-c", child_code, str(result_file), spaced_argument]
+
+    monkeypatch.chdir(working_directory)
+
+    with pytest.raises(SystemExit) as exc_info:
+        downloads._replace_process(downloads.sys.executable, argv)
+
+    assert exc_info.value.code == 17
+    child_cwd, child_argument = result_file.read_text(encoding="utf-8").splitlines()
+    assert downloads.os.path.normcase(child_cwd) == downloads.os.path.normcase(str(working_directory))
+    assert child_argument == spaced_argument


### PR DESCRIPTION
## Summary

- keep the updater process waiting for the replacement worker on Windows so the invoking shell does not regain control early
- launch the replacement with a subprocess argument list and explicit executable/working directory, preserving paths and arguments containing spaces
- retain `os.execv()` on POSIX for supervisor-compatible process replacement
- avoid logging forwarded command-line arguments, which may contain `--key`
- add a Windows fast-test CI job and a real Windows process test

Closes #67.

## Validation

- `uv run pytest tests/test_downloads.py -q` (8 passed, 1 Windows-only test skipped)
- `uv run pytest -m "not engine"` (92 passed, 1 Windows-only test skipped, 4 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`

The Windows-only integration test creates a working directory and output path containing spaces, passes a spaced argument to a real child Python process, verifies that the parent waits, and checks exit-code propagation. It will run on the new `windows-latest` CI job.
